### PR TITLE
Logical Fixes and QOL Updates

### DIFF
--- a/FrontEnd/myapp/src/Login.js
+++ b/FrontEnd/myapp/src/Login.js
@@ -98,7 +98,13 @@ function LogIn(props) {
         <Col>
           <h2>Welcome</h2>
         </Col>
-        <Col></Col>
+        <Col>
+          <p>Don't have an account?&nbsp; 
+            <Link to ="/signup">
+              Sign Up
+            </Link>
+          </p>
+        </Col>
       </Row>
       <div className="app">
         <div className="login-form">

--- a/FrontEnd/myapp/src/SignUp.js
+++ b/FrontEnd/myapp/src/SignUp.js
@@ -96,7 +96,14 @@ function SignUp(props) {
         <Col>
           <h2>Welcome</h2>
         </Col>
-        <Col></Col>
+        <Col>
+          <p>
+            Already have an account?&nbsp;
+            <Link to ="/login">
+              Log In
+            </Link>
+          </p>
+        </Col>
       </Row>
       <div className="app">
         <div className="login-form">

--- a/FrontEnd/myapp/src/StockCheck.js
+++ b/FrontEnd/myapp/src/StockCheck.js
@@ -12,23 +12,24 @@ const apiKey = "RZEXR5SFIKLQNKYK";
 
 function StockCheck() {
   let myvalue, myquery;
-  const [price, setPrice] = useState(null);
-  const [ticker, setTicker] = useState("");
+  const [message, setMessage] = useState("");
 
   async function HandleSubmit(e) {
     console.log(e.target.ticker.value);
     e.preventDefault();
-    setTicker(e.target.ticker.value.toUpperCase());
-    //console.log(ticker)
+    const ticker = e.target.ticker.value.toUpperCase()
+    //console.log("Ticker: ", ticker)
     //calls the API using the stock ticker
-    const stockPrice = await checkPrice(e.target.ticker.value.toUpperCase());
-    //console.log(stockPrice)
+    const stockPrice = await checkPrice(ticker);
+    //console.log("Price: ", stockPrice)
     //the object that is extracted from the API response, since it is not a list we must do extra processing
     //const timeSeriesObject = stockPrice["data"]["Time Series (1min)"];
     //extract the first key from the JSON, corresponds to the latest minute of data returned
     //const firstKey = Object.keys(timeSeriesObject)[0];
     //set the price of the stock using the key we extracted and take the closing price
-    setPrice(stockPrice);
+    const message = "The value of ".concat(ticker).concat(" is $").concat(stockPrice);
+    setMessage(message);
+    //console.log("Message: ", message);
     // console.log(firstKey)
     // console.log(stockPrice["data"]["Time Series (1min)"][firstKey]["4. close"])
   }
@@ -61,7 +62,7 @@ function StockCheck() {
           </div>
         </form>
         <p>
-          The current price of {ticker} is: $ {price ? price : ""}
+          {message}
         </p>
       </main>
       <nav>

--- a/FrontEnd/myapp/src/WatchList.js
+++ b/FrontEnd/myapp/src/WatchList.js
@@ -62,7 +62,11 @@ function Watchlist(props) {
     const toBeAdded = e.target.watch.value;
     console.log(toBeAdded);
     e.preventDefault();
-    if (personalWatchlist.includes(toBeAdded)) {
+    if (
+      personalWatchlist.findIndex((item) => {
+        return item.name == toBeAdded;
+      }) != -1
+    ) {
       alert("Already on watchlist");
       return;
     }

--- a/FrontEnd/myapp/src/buysell.js
+++ b/FrontEnd/myapp/src/buysell.js
@@ -61,6 +61,10 @@ class Buy extends React.Component {
   async handleSubmit(event) {
     event.preventDefault();
     if (this.state.name != "" && this.state.numberOfShares != null) {
+      if (isNaN(this.state.numberOfShares) || this.state.numberOfShares <= 0) {
+        alert("Please enter a positive number.");
+        return;
+      }
       if (
         window.confirm(
           `Buy ${this.state.numberOfShares} shares of ${this.state.name}?`
@@ -92,6 +96,7 @@ class Buy extends React.Component {
       alert("Enter a stock to buy");
     }
   }
+
   render() {
     return (
       <>
@@ -190,7 +195,12 @@ class Sell extends React.Component {
   }
 
   async handleSubmit(event) {
+    event.preventDefault();
     if (this.state.name != "" && this.state.numberOfShares != null) {
+      if (isNaN(this.state.numberOfShares) || this.state.numberOfShares <= 0) {
+        alert("Please enter a positive number.");
+        return;
+      }
       if (
         window.confirm(
           `Sell ${this.state.numberOfShares} shares of ${this.state.name}?`
@@ -213,8 +223,6 @@ class Sell extends React.Component {
     } else {
       alert("Enter a stock to sell");
     }
-
-    event.preventDefault();
   }
 
   render() {


### PR DESCRIPTION
Specific changes:
- StockCheck has no more out-of-place text before the user makes a price call
- Added more validation to buy/sell input (no negatives, no non-numbers) See issue #51 for more info
- No longer able to add duplicates to the watchlist
- Now able to navigate between log-in and sign-up pages directly without going to the home page